### PR TITLE
fix: replace curl with wget in Dockerfile HEALTHCHECK

### DIFF
--- a/PodcastScrobbler/Dockerfile
+++ b/PodcastScrobbler/Dockerfile
@@ -17,6 +17,6 @@ ENV DATABASE_PATH=/data/scrobbles.db
 EXPOSE 5000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:5000/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:5000/health || exit 1
 
 ENTRYPOINT ["dotnet", "PodcastScrobbler.dll"]

--- a/PodcastScrobbler/containerapp.yaml
+++ b/PodcastScrobbler/containerapp.yaml
@@ -18,6 +18,23 @@ properties:
             value: "/data/scrobbles.db"
           - name: SCROBBLER_TOKEN
             secretRef: scrobbler-token
+        probes:
+          - type: liveness
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          - type: readiness
+            httpGet:
+              path: /ready
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
         volumeMounts:
           - volumeName: scrobbler-data
             mountPath: /data


### PR DESCRIPTION
## Problem

The HEALTHCHECK in Dockerfile uses \curl\, which is not available in the \mcr.microsoft.com/dotnet/aspnet:10.0\ base image. This causes the health check to always fail, and container orchestrators (Docker Compose, Kubernetes, Azure Container Apps) will restart a perfectly healthy container in a loop.

## Changes

### \Dockerfile\
- Replace \curl -f\ with \wget --no-verbose --tries=1 --spider\ — \wget\ is available in the Debian-based aspnet runtime image and follows the same fail-fast pattern

### \containerapp.yaml\
- Add explicit \liveness\ probe targeting \/health\ (30s interval)
- Add explicit \eadiness\ probe targeting \/ready\ (10s interval)

## Verification

\\\ash
docker build -t podcast-scrobbler .
docker run -d --name test podcast-scrobbler
# Wait 35s for first health check
docker inspect --format='{{.State.Health.Status}}' test
# Should show: healthy
\\\

Closes #1