### PR TITLE
fix: reject GET listens with both max_ts and min_ts

### DIFF
--- a/PodcastScrobbler.Tests/Endpoints/GetListensTests.cs
+++ b/PodcastScrobbler.Tests/Endpoints/GetListensTests.cs
@@ -64,4 +64,15 @@ public class GetListensTests : IClassFixture<ScrobblerWebApplicationFactory>
         var listens = content.GetProperty("payload").GetProperty("listens");
         Assert.True(listens.GetArrayLength() > 0);
     }
+
+    [Fact]
+    public async Task GetListens_BothMaxTsAndMinTs_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync("/1/user/default/listens?max_ts=1740099999&min_ts=1740098000");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("max_ts", body.GetProperty("error").GetString());
+        Assert.Contains("min_ts", body.GetProperty("error").GetString());
+    }
 }

--- a/PodcastScrobbler/Endpoints/GetListensEndpoint.cs
+++ b/PodcastScrobbler/Endpoints/GetListensEndpoint.cs
@@ -8,6 +8,9 @@ public static class GetListensEndpoint
     {
         app.MapGet("/1/user/{username}/listens", async (string username, int? count, long? max_ts, long? min_ts, ListenRepository repo) =>
         {
+            if (max_ts.HasValue && min_ts.HasValue)
+                return Results.BadRequest(new { error = "Cannot specify both max_ts and min_ts." });
+
             var actualCount = Math.Clamp(count ?? 25, 1, 100);
 
             var listens = await repo.GetListens(username, actualCount, max_ts, min_ts);


### PR DESCRIPTION
## Problem

Per the ListenBrainz spec (`SCAFFOLD.md`): `max_ts` and `min_ts` are mutually exclusive — only one may be specified. Previously both were silently accepted; `min_ts` was ignored due to the `else if` branch in `ListenRepository.GetListens()`, returning confusing results with no error feedback to the client.

## Change

Single guard clause added to `GetListensEndpoint.cs`:

```csharp
if (max_ts.HasValue && min_ts.HasValue)
    return Results.BadRequest(new { error = "Cannot specify both max_ts and min_ts." });
```

## Test

`GetListens_BothMaxTsAndMinTs_ReturnsBadRequest` — verifies 400 status and that the error message names both parameters.

Closes #11
