### PR TITLE
fix: write DB before updating in-memory cache in PlayingNowStore.Set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ obj/
 .vscode/
 
 ## Data
-data/
+/data/
 *.db
 
 ## OS

--- a/PodcastScrobbler.Tests/Data/ListenRepositoryTests.cs
+++ b/PodcastScrobbler.Tests/Data/ListenRepositoryTests.cs
@@ -1,0 +1,103 @@
+using PodcastScrobbler.Config;
+using PodcastScrobbler.Data;
+using PodcastScrobbler.Models;
+
+namespace PodcastScrobbler.Tests.Data;
+
+public class ListenRepositoryTests : IDisposable
+{
+    private readonly DuckDbContext _db;
+    private readonly ListenRepository _repo;
+
+    public ListenRepositoryTests()
+    {
+        var config = new ScrobblerConfig { DatabasePath = ":memory:" };
+        _db = new DuckDbContext(config);
+        _db.Initialize().GetAwaiter().GetResult();
+        _repo = new ListenRepository(_db);
+    }
+
+    [Fact]
+    public async Task InsertAndGetListen_Works()
+    {
+        var listen = new Listen
+        {
+            Username = "testuser",
+            ListenedAt = 1740098330,
+            ArtistName = "Test Podcast",
+            TrackName = "Episode 1"
+        };
+        await _repo.InsertListen(listen);
+
+        var listens = await _repo.GetListens("testuser", 10, null, null);
+        Assert.Single(listens);
+        Assert.Equal("Test Podcast", listens[0].ArtistName);
+        Assert.Equal("Episode 1", listens[0].TrackName);
+    }
+
+    [Fact]
+    public async Task GetListenCount_ReturnsCorrectCount()
+    {
+        await _repo.InsertListen(new Listen { Username = "counter", ListenedAt = 1, ArtistName = "A", TrackName = "1" });
+        await _repo.InsertListen(new Listen { Username = "counter", ListenedAt = 2, ArtistName = "A", TrackName = "2" });
+
+        var count = await _repo.GetListenCount("counter");
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task GetTopPodcasts_GroupsByArtist()
+    {
+        await _repo.InsertListen(new Listen { Username = "stats", ListenedAt = 1, ArtistName = "Pod A", TrackName = "E1" });
+        await _repo.InsertListen(new Listen { Username = "stats", ListenedAt = 2, ArtistName = "Pod A", TrackName = "E2" });
+        await _repo.InsertListen(new Listen { Username = "stats", ListenedAt = 3, ArtistName = "Pod B", TrackName = "E1" });
+
+        var top = await _repo.GetTopPodcasts("stats", 10);
+        Assert.Equal(2, top.Count);
+        Assert.Equal("Pod A", top[0].PodcastName);
+        Assert.Equal(2, top[0].ListenCount);
+    }
+
+    [Fact]
+    public async Task GetSummary_ReturnsAggregate()
+    {
+        await _repo.InsertListen(new Listen { Username = "sum", ListenedAt = 1, ArtistName = "P1", TrackName = "E1" });
+        await _repo.InsertListen(new Listen { Username = "sum", ListenedAt = 2, ArtistName = "P1", TrackName = "E2" });
+        await _repo.InsertListen(new Listen { Username = "sum", ListenedAt = 3, ArtistName = "P2", TrackName = "E3" });
+
+        var summary = await _repo.GetSummary("sum");
+        Assert.Equal(3, summary.TotalListens);
+        Assert.Equal(2, summary.UniquePodcasts);
+        Assert.Equal(3, summary.UniqueEpisodes);
+    }
+
+    [Fact]
+    public async Task InsertListenWithAdditionalInfo_RoundTrips()
+    {
+        var listen = new Listen
+        {
+            Username = "info",
+            ListenedAt = 1,
+            ArtistName = "Pod",
+            TrackName = "Ep",
+            AdditionalInfo = new AdditionalInfo
+            {
+                MediaPlayer = "podcast-tui",
+                DurationMs = 3600000,
+                PositionMs = 1800000
+            }
+        };
+        await _repo.InsertListen(listen);
+
+        var listens = await _repo.GetListens("info", 1, null, null);
+        Assert.NotNull(listens[0].AdditionalInfo);
+        Assert.Equal("podcast-tui", listens[0].AdditionalInfo!.MediaPlayer);
+        Assert.Equal(3600000, listens[0].AdditionalInfo!.DurationMs);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/PodcastScrobbler.Tests/Data/PlayingNowStoreTests.cs
+++ b/PodcastScrobbler.Tests/Data/PlayingNowStoreTests.cs
@@ -1,0 +1,73 @@
+using PodcastScrobbler.Config;
+using PodcastScrobbler.Data;
+using PodcastScrobbler.Models;
+
+namespace PodcastScrobbler.Tests.Data;
+
+public class PlayingNowStoreTests : IDisposable
+{
+    private readonly DuckDbContext _db;
+    private readonly PlayingNowStore _store;
+
+    public PlayingNowStoreTests()
+    {
+        var config = new ScrobblerConfig { DatabasePath = ":memory:" };
+        _db = new DuckDbContext(config);
+        _db.Initialize().GetAwaiter().GetResult();
+        _store = new PlayingNowStore(_db);
+    }
+
+    [Fact]
+    public void Get_NoState_ReturnsNull()
+    {
+        var result = _store.Get("nobody");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SetAndGet_Works()
+    {
+        var playingNow = new PlayingNow
+        {
+            Username = "testuser",
+            ArtistName = "Test Pod",
+            TrackName = "Current Ep"
+        };
+        await _store.Set(playingNow);
+
+        var result = _store.Get("testuser");
+        Assert.NotNull(result);
+        Assert.Equal("Test Pod", result!.ArtistName);
+        Assert.Equal("Current Ep", result.TrackName);
+    }
+
+    [Fact]
+    public async Task SetOverwrites_PreviousState()
+    {
+        await _store.Set(new PlayingNow { Username = "user", ArtistName = "Pod1", TrackName = "Ep1" });
+        await _store.Set(new PlayingNow { Username = "user", ArtistName = "Pod2", TrackName = "Ep2" });
+
+        var result = _store.Get("user");
+        Assert.Equal("Pod2", result!.ArtistName);
+    }
+
+    [Fact]
+    public async Task LoadFromDb_RestoresState()
+    {
+        await _store.Set(new PlayingNow { Username = "persist", ArtistName = "Pod", TrackName = "Ep" });
+
+        // Create a new store from the same DB to simulate restart
+        var newStore = new PlayingNowStore(_db);
+        await newStore.LoadFromDb();
+
+        var result = newStore.Get("persist");
+        Assert.NotNull(result);
+        Assert.Equal("Pod", result!.ArtistName);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/PodcastScrobbler/Data/DuckDbContext.cs
+++ b/PodcastScrobbler/Data/DuckDbContext.cs
@@ -1,0 +1,80 @@
+using DuckDB.NET.Data;
+using PodcastScrobbler.Config;
+
+namespace PodcastScrobbler.Data;
+
+public class DuckDbContext : IDisposable
+{
+    private readonly DuckDBConnection _writeConnection;
+    private readonly string _connectionString;
+    private readonly bool _isInMemory;
+
+    public DuckDbContext(ScrobblerConfig config)
+    {
+        var dbPath = config.DatabasePath;
+        _isInMemory = dbPath == ":memory:";
+
+        if (!_isInMemory)
+        {
+            var dir = Path.GetDirectoryName(dbPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+        }
+
+        _connectionString = $"Data Source={dbPath}";
+        _writeConnection = new DuckDBConnection(_connectionString);
+        _writeConnection.Open();
+    }
+
+    public async Task Initialize()
+    {
+        using var cmd = _writeConnection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS listens (
+                id            UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+                username      VARCHAR NOT NULL,
+                listened_at   BIGINT NOT NULL,
+                artist_name   VARCHAR NOT NULL,
+                track_name    VARCHAR NOT NULL,
+                additional_info JSON,
+                created_at    TIMESTAMPTZ DEFAULT now()
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_listens_user_time ON listens (username, listened_at DESC);
+
+            CREATE TABLE IF NOT EXISTS playing_now (
+                username      VARCHAR PRIMARY KEY,
+                updated_at    TIMESTAMPTZ DEFAULT now(),
+                artist_name   VARCHAR NOT NULL,
+                track_name    VARCHAR NOT NULL,
+                additional_info JSON
+            );
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public DuckDBConnection GetConnection() => _writeConnection;
+
+    /// <summary>
+    /// Returns a read connection. For in-memory databases, returns the write connection
+    /// since each in-memory connection is a separate database instance.
+    /// Callers should only Dispose connections from file-backed databases.
+    /// </summary>
+    public DuckDBConnection GetReadConnection()
+    {
+        if (_isInMemory)
+            return _writeConnection;
+
+        var conn = new DuckDBConnection(_connectionString);
+        conn.Open();
+        return conn;
+    }
+
+    public bool IsInMemory => _isInMemory;
+
+    public void Dispose()
+    {
+        _writeConnection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/PodcastScrobbler/Data/ListenRepository.cs
+++ b/PodcastScrobbler/Data/ListenRepository.cs
@@ -1,0 +1,237 @@
+using System.Text.Json;
+using DuckDB.NET.Data;
+using PodcastScrobbler.Models;
+
+namespace PodcastScrobbler.Data;
+
+public class ListenRepository
+{
+    private readonly DuckDbContext _db;
+    private static readonly JsonSerializerOptions JsonOptions = new() { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
+
+    public ListenRepository(DuckDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task InsertListen(Listen listen)
+    {
+        var conn = _db.GetConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT INTO listens (id, username, listened_at, artist_name, track_name, additional_info) VALUES ($1, $2, $3, $4, $5, $6)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = listen.Id.ToString() });
+        cmd.Parameters.Add(new DuckDBParameter { Value = listen.Username });
+        cmd.Parameters.Add(new DuckDBParameter { Value = listen.ListenedAt });
+        cmd.Parameters.Add(new DuckDBParameter { Value = listen.ArtistName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = listen.TrackName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = SerializeAdditionalInfo(listen.AdditionalInfo) });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task InsertListens(IEnumerable<Listen> listens)
+    {
+        foreach (var listen in listens)
+        {
+            await InsertListen(listen);
+        }
+    }
+
+    public async Task<List<Listen>> GetListens(string username, int count, long? maxTs, long? minTs)
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+
+            var sql = "SELECT id, username, listened_at, artist_name, track_name, additional_info, created_at FROM listens WHERE username = $1";
+            cmd.Parameters.Add(new DuckDBParameter { Value = username });
+
+            if (maxTs.HasValue)
+            {
+                sql += " AND listened_at < $2";
+                cmd.Parameters.Add(new DuckDBParameter { Value = maxTs.Value });
+            }
+            else if (minTs.HasValue)
+            {
+                sql += " AND listened_at > $2";
+                cmd.Parameters.Add(new DuckDBParameter { Value = minTs.Value });
+            }
+
+            sql += " ORDER BY listened_at DESC LIMIT " + count;
+            cmd.CommandText = sql;
+
+            var listens = new List<Listen>();
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                listens.Add(ReadListen(reader));
+            }
+            return listens;
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    public async Task<int> GetListenCount(string username)
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM listens WHERE username = $1";
+            cmd.Parameters.Add(new DuckDBParameter { Value = username });
+            var result = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(result);
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    public async Task<List<PodcastStats>> GetTopPodcasts(string username, int limit)
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                SELECT artist_name, COUNT(*) as listen_count,
+                       COALESCE(SUM(CAST(json_extract(additional_info, '$.duration_ms') AS BIGINT)), 0) as total_time
+                FROM listens WHERE username = $1
+                GROUP BY artist_name ORDER BY listen_count DESC
+                """ + $" LIMIT {limit}";
+            cmd.Parameters.Add(new DuckDBParameter { Value = username });
+
+            var stats = new List<PodcastStats>();
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                stats.Add(new PodcastStats
+                {
+                    PodcastName = reader.GetString(0),
+                    ListenCount = Convert.ToInt32(reader.GetValue(1)),
+                    TotalListenTimeMs = reader.IsDBNull(2) ? 0 : long.Parse(reader.GetValue(2)!.ToString()!)
+                });
+            }
+            return stats;
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    public async Task<List<WeeklyStats>> GetWeeklyStats(string username, int weeks)
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                SELECT CAST(date_trunc('week', to_timestamp(listened_at)) AS DATE) as week_start,
+                       COUNT(*) as listen_count,
+                       COALESCE(SUM(CAST(json_extract(additional_info, '$.duration_ms') AS BIGINT)), 0) as total_time
+                FROM listens WHERE username = $1
+                  AND listened_at >= extract(epoch FROM now() - INTERVAL '{weeks} weeks')::BIGINT
+                GROUP BY week_start ORDER BY week_start DESC
+                """.Replace("{weeks}", weeks.ToString());
+            cmd.Parameters.Add(new DuckDBParameter { Value = username });
+
+            var stats = new List<WeeklyStats>();
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                stats.Add(new WeeklyStats
+                {
+                    WeekStart = reader.GetValue(0)?.ToString() ?? "",
+                    ListenCount = Convert.ToInt32(reader.GetValue(1)),
+                    TotalListenTimeMs = reader.IsDBNull(2) ? 0 : long.Parse(reader.GetValue(2)!.ToString()!)
+                });
+            }
+            return stats;
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    public async Task<List<string>> GetRecentPodcasts(string username, int limit)
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT artist_name FROM listens WHERE username = $1 GROUP BY artist_name ORDER BY MAX(listened_at) DESC LIMIT {limit}";
+            cmd.Parameters.Add(new DuckDBParameter { Value = username });
+
+            var podcasts = new List<string>();
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                podcasts.Add(reader.GetString(0));
+            }
+            return podcasts;
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    public async Task<ListenSummary> GetSummary(string username)
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                SELECT COUNT(*) as total_listens,
+                       COALESCE(SUM(CAST(json_extract(additional_info, '$.duration_ms') AS BIGINT)), 0) as total_time,
+                       COUNT(DISTINCT artist_name) as unique_podcasts,
+                       COUNT(DISTINCT track_name) as unique_episodes
+                FROM listens WHERE username = $1
+                """;
+            cmd.Parameters.Add(new DuckDBParameter { Value = username });
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+            return new ListenSummary
+            {
+                TotalListens = Convert.ToInt32(reader.GetValue(0)),
+                TotalListenTimeMs = reader.IsDBNull(1) ? 0 : long.Parse(reader.GetValue(1)!.ToString()!),
+                UniquePodcasts = Convert.ToInt32(reader.GetValue(2)),
+                UniqueEpisodes = Convert.ToInt32(reader.GetValue(3))
+            };
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    private static Listen ReadListen(System.Data.Common.DbDataReader reader)
+    {
+        var additionalInfoStr = reader.IsDBNull(5) ? null : reader.GetValue(5)?.ToString();
+        return new Listen
+        {
+            Id = Guid.Parse(reader.GetValue(0)?.ToString() ?? Guid.NewGuid().ToString()),
+            Username = reader.GetString(1),
+            ListenedAt = Convert.ToInt64(reader.GetValue(2)),
+            ArtistName = reader.GetString(3),
+            TrackName = reader.GetString(4),
+            AdditionalInfo = string.IsNullOrEmpty(additionalInfoStr)
+                ? null
+                : JsonSerializer.Deserialize<AdditionalInfo>(additionalInfoStr, JsonOptions),
+            CreatedAt = reader.IsDBNull(6) ? DateTimeOffset.UtcNow : DateTimeOffset.Parse(reader.GetValue(6)!.ToString()!)
+        };
+    }
+
+    private static string? SerializeAdditionalInfo(AdditionalInfo? info)
+    {
+        return info is null ? null : JsonSerializer.Serialize(info, JsonOptions);
+    }
+}

--- a/PodcastScrobbler/Data/PlayingNowStore.cs
+++ b/PodcastScrobbler/Data/PlayingNowStore.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using DuckDB.NET.Data;
+using PodcastScrobbler.Models;
+
+namespace PodcastScrobbler.Data;
+
+public class PlayingNowStore
+{
+    private readonly ConcurrentDictionary<string, PlayingNow> _store = new();
+    private readonly DuckDbContext _db;
+    private static readonly JsonSerializerOptions JsonOptions = new() { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
+
+    public PlayingNowStore(DuckDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task LoadFromDb()
+    {
+        var conn = _db.GetReadConnection();
+        try
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT username, updated_at, artist_name, track_name, additional_info FROM playing_now";
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var additionalInfoStr = reader.IsDBNull(4) ? null : reader.GetValue(4)?.ToString();
+                var playingNow = new PlayingNow
+                {
+                    Username = reader.GetString(0),
+                    UpdatedAt = DateTimeOffset.Parse(reader.GetValue(1)!.ToString()!),
+                    ArtistName = reader.GetString(2),
+                    TrackName = reader.GetString(3),
+                    AdditionalInfo = string.IsNullOrEmpty(additionalInfoStr)
+                        ? null
+                        : JsonSerializer.Deserialize<AdditionalInfo>(additionalInfoStr, JsonOptions)
+                };
+                _store[playingNow.Username] = playingNow;
+            }
+        }
+        finally
+        {
+            if (!_db.IsInMemory) conn.Dispose();
+        }
+    }
+
+    public async Task Set(PlayingNow playingNow)
+    {
+        var conn = _db.GetConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO playing_now (username, artist_name, track_name, additional_info)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (username) DO UPDATE SET
+                artist_name = EXCLUDED.artist_name,
+                track_name = EXCLUDED.track_name,
+                additional_info = EXCLUDED.additional_info,
+                updated_at = now()
+            """;
+        cmd.Parameters.Add(new DuckDBParameter { Value = playingNow.Username });
+        cmd.Parameters.Add(new DuckDBParameter { Value = playingNow.ArtistName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = playingNow.TrackName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = playingNow.AdditionalInfo is null ? null : JsonSerializer.Serialize(playingNow.AdditionalInfo, JsonOptions) });
+        await cmd.ExecuteNonQueryAsync();
+
+        _store[playingNow.Username] = playingNow;
+    }
+
+    public PlayingNow? Get(string username)
+    {
+        _store.TryGetValue(username, out var playingNow);
+        return playingNow;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #12

Swaps the order in PlayingNowStore.Set() so the DuckDB UPSERT completes before the in-memory ConcurrentDictionary is updated. If the DB write throws, memory stays consistent with the database.

### Changes

- **PodcastScrobbler/Data/PlayingNowStore.cs** — moved _store[playingNow.Username] = playingNow; to after wait cmd.ExecuteNonQueryAsync()
- **.gitignore** — changed data/ to /data/ (anchored to repo root) to stop accidentally ignoring source Data/ directories on case-insensitive filesystems

### Verification

All 30 existing tests pass. Correctness is verifiable by code inspection: _store is now only updated on successful DB write.