### PR TITLE
fix: report imported/skipped counts in import response

### DIFF
--- a/PodcastScrobbler.Tests/Endpoints/SubmitListensTests.cs
+++ b/PodcastScrobbler.Tests/Endpoints/SubmitListensTests.cs
@@ -68,7 +68,7 @@ public class SubmitListensTests : IClassFixture<ScrobblerWebApplicationFactory>
     }
 
     [Fact]
-    public async Task SubmitImport_ReturnsOk()
+    public async Task SubmitImport_ReturnsOkWithCounts()
     {
         var request = new
         {
@@ -90,6 +90,33 @@ public class SubmitListensTests : IClassFixture<ScrobblerWebApplicationFactory>
 
         var response = await _client.PostAsJsonAsync("/1/submit-listens", request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("ok", body.GetProperty("status").GetString());
+        Assert.Equal(2, body.GetProperty("imported").GetInt32());
+        Assert.Equal(0, body.GetProperty("skipped").GetInt32());
+    }
+
+    [Fact]
+    public async Task ImportWithMissingTimestamps_ReportsSkippedCount()
+    {
+        var request = new
+        {
+            listen_type = "import",
+            payload = new object[]
+            {
+                new { listened_at = 1740098330L, track_metadata = new { artist_name = "Pod", track_name = "Ep1" } },
+                new { track_metadata = new { artist_name = "Pod", track_name = "Ep2" } }  // missing listened_at
+            }
+        };
+
+        var response = await _client.PostAsJsonAsync("/1/submit-listens", request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("ok", body.GetProperty("status").GetString());
+        Assert.Equal(1, body.GetProperty("imported").GetInt32());
+        Assert.Equal(1, body.GetProperty("skipped").GetInt32());
     }
 
     [Fact]

--- a/PodcastScrobbler/Endpoints/SubmitListensEndpoint.cs
+++ b/PodcastScrobbler/Endpoints/SubmitListensEndpoint.cs
@@ -59,18 +59,20 @@ public static class SubmitListensEndpoint
 
                 case "import":
                 {
-                    var listens = request.Payload
-                        .Where(p => p.ListenedAt.HasValue)
-                        .Select(p => new Listen
-                        {
-                            Username = "default",
-                            ListenedAt = p.ListenedAt!.Value,
-                            ArtistName = p.TrackMetadata.ArtistName,
-                            TrackName = p.TrackMetadata.TrackName,
-                            AdditionalInfo = p.TrackMetadata.AdditionalInfo
-                        });
+                    var valid = request.Payload.Where(p => p.ListenedAt.HasValue).ToList();
+                    var skipped = request.Payload.Count - valid.Count;
+
+                    var listens = valid.Select(p => new Listen
+                    {
+                        Username = "default",
+                        ListenedAt = p.ListenedAt!.Value,
+                        ArtistName = p.TrackMetadata.ArtistName,
+                        TrackName = p.TrackMetadata.TrackName,
+                        AdditionalInfo = p.TrackMetadata.AdditionalInfo
+                    });
                     await repo.InsertListens(listens);
-                    break;
+
+                    return Results.Ok(new { status = "ok", imported = valid.Count, skipped });
                 }
             }
 


### PR DESCRIPTION
## Problem

The `import` case in `SubmitListensEndpoint` silently filtered out payload items missing `listened_at` with no indication in the response. If a client sent 100 items and 5 lacked timestamps, 95 were imported and the response was still `{"status":"ok"}`.

## Changes

### `SubmitListensEndpoint.cs`
- Split payload into `valid` (has `listened_at`) and `skipped` count before inserting
- Import case now returns `{"status":"ok","imported":<n>,"skipped":<n>}` - backwards-compatible; LB clients check `status == "ok"` and ignore extra fields
- Other listen types (`single`, `playing_now`) are unchanged

### `SubmitListensTests.cs`
- Updated `SubmitImport_ReturnsOk` to assert `imported` and `skipped` fields
- Added `ImportWithMissingTimestamps_ReportsSkippedCount`: sends 2 items (1 with, 1 without `listened_at`), asserts `imported=1, skipped=1`

Closes #13
