### PR TITLE
refactor: ScrobblerConfig as plain POCO with standard config binding

### DIFF
--- a/PodcastScrobbler/Config/ScrobblerConfig.cs
+++ b/PodcastScrobbler/Config/ScrobblerConfig.cs
@@ -2,15 +2,8 @@ namespace PodcastScrobbler.Config;
 
 public class ScrobblerConfig
 {
-    public string DatabasePath { get; set; } =
-        Environment.GetEnvironmentVariable("DATABASE_PATH") ?? "./data/scrobbles.db";
-
-    public string? ScrobblerToken { get; set; } =
-        Environment.GetEnvironmentVariable("SCROBBLER_TOKEN");
-
-    public bool RequireAuthForReads { get; set; } =
-        string.Equals(Environment.GetEnvironmentVariable("SCROBBLER_REQUIRE_AUTH_FOR_READS"), "true", StringComparison.OrdinalIgnoreCase);
-
-    public string Port { get; set; } =
-        Environment.GetEnvironmentVariable("PORT") ?? "5000";
+    public string DatabasePath { get; set; } = "./data/scrobbles.db";
+    public string? ScrobblerToken { get; set; }
+    public bool RequireAuthForReads { get; set; } = false;
+    public string Port { get; set; } = "5000";
 }

--- a/PodcastScrobbler/Program.cs
+++ b/PodcastScrobbler/Program.cs
@@ -8,7 +8,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Configuration
 var config = new ScrobblerConfig();
-builder.Configuration.Bind(config);
+builder.Configuration.GetSection("Scrobbler").Bind(config);
+
+// Env vars take precedence (explicit overlay)
+if (Environment.GetEnvironmentVariable("DATABASE_PATH") is { } dbPath)
+    config.DatabasePath = dbPath;
+if (Environment.GetEnvironmentVariable("SCROBBLER_TOKEN") is { } token)
+    config.ScrobblerToken = token;
+if (Environment.GetEnvironmentVariable("SCROBBLER_REQUIRE_AUTH_FOR_READS") is { } authReads)
+    config.RequireAuthForReads = string.Equals(authReads, "true", StringComparison.OrdinalIgnoreCase);
+if (Environment.GetEnvironmentVariable("PORT") is { } envPort)
+    config.Port = envPort;
+
 builder.Services.AddSingleton(config);
 
 // Port configuration

--- a/PodcastScrobbler/appsettings.json
+++ b/PodcastScrobbler/appsettings.json
@@ -5,6 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "DatabasePath": "./data/scrobbles.db",
+  "Scrobbler": {
+    "DatabasePath": "./data/scrobbles.db"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Closes #8

## Summary

Refactors ScrobblerConfig to be a plain POCO and moves configuration to standard ASP.NET Core config binding.

### Changes

- **ScrobblerConfig.cs**: Removed Environment.GetEnvironmentVariable calls from property initializers; now a plain POCO with simple defaults.
- **Program.cs**: Binds config from the Scrobbler section of ppsettings.json, then explicitly overlays env vars for clear, documented precedence.
- **ppsettings.json**: Moved DatabasePath into a Scrobbler section to match the new binding path.