### PR TITLE
feat: validate PORT config value at startup with clear diagnostic

### DIFF
--- a/PodcastScrobbler/Program.cs
+++ b/PodcastScrobbler/Program.cs
@@ -11,9 +11,13 @@ var config = new ScrobblerConfig();
 builder.Configuration.Bind(config);
 builder.Services.AddSingleton(config);
 
-// Port configuration
-var port = config.Port;
-builder.WebHost.UseUrls($"http://+:{port}");
+// Port configuration — validate before Kestrel attempts to bind
+if (!int.TryParse(config.Port, out var parsedPort) || parsedPort < 1 || parsedPort > 65535)
+{
+    Console.Error.WriteLine($"[crit] Invalid configuration value for 'Port': '{config.Port}'. Must be an integer between 1 and 65535. Exiting application.");
+    Environment.Exit(1);
+}
+builder.WebHost.UseUrls($"http://+:{parsedPort}");
 
 // DI registrations
 builder.Services.AddSingleton<DuckDbContext>();
@@ -39,7 +43,7 @@ await playingNowStore.LoadFromDb();
 // Startup diagnostics
 app.Logger.LogInformation("Database: {Path}", config.DatabasePath);
 app.Logger.LogInformation("Auth: {Status}", string.IsNullOrEmpty(config.ScrobblerToken) ? "disabled" : "enabled");
-app.Logger.LogInformation("Listening on port {Port}", config.Port);
+app.Logger.LogInformation("Listening on port {Port}", parsedPort);
 
 // Global exception handler — must be first in pipeline to catch all downstream exceptions
 app.UseExceptionHandler(errorApp =>


### PR DESCRIPTION
## Summary

Adds early validation of the `Port` config value in `Program.cs` before Kestrel attempts to bind, preventing an unfriendly stack trace when an invalid value is supplied.

## Changes

- Added `int.TryParse` + range check (1-65535) immediately after config binding
- On invalid value: writes `[crit] Invalid port value '...'` to `Console.Error` and exits early (before the app host is built, so `app.Logger` is not available yet)
- Updated `UseUrls` and startup log to use the parsed `int` rather than the raw `string`
- `ScrobblerConfig.Port` remains `string` - no model change required

## Testing

All existing tests continue to pass. The factory uses `Port = "5000"` which is valid.

Closes #20