### PR TITLE
test: add coverage for health, stats, additional_info round-trip, count clamping, ts filtering, and RequireAuthForReads

### DIFF
--- a/PodcastScrobbler.Tests/Endpoints/GetListensTests.cs
+++ b/PodcastScrobbler.Tests/Endpoints/GetListensTests.cs
@@ -75,4 +75,152 @@ public class GetListensTests : IClassFixture<ScrobblerWebApplicationFactory>
         Assert.Contains("max_ts", body.GetProperty("error").GetString());
         Assert.Contains("min_ts", body.GetProperty("error").GetString());
     }
+
+    [Fact]
+    public async Task GetListens_CountClampedToMinimum()
+    {
+        // Seed 2 listens so the clamp is observable: count=0 → clamped to 1 → only 1 returned
+        await _client.PostAsJsonAsync("/1/submit-listens", new
+        {
+            listen_type = "import",
+            payload = new[]
+            {
+                new { listened_at = 1740600001L, track_metadata = new { artist_name = "Clamp Min Pod", track_name = "Ep 1" } },
+                new { listened_at = 1740600002L, track_metadata = new { artist_name = "Clamp Min Pod", track_name = "Ep 2" } }
+            }
+        });
+
+        var response = await _client.GetAsync("/1/user/default/listens?count=0");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var payload = content.GetProperty("payload");
+        Assert.Equal(1, payload.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public async Task GetListens_CountClampedToMaximum()
+    {
+        // Seed 101 listens so the clamp is observable: count=200 → clamped to 100 → exactly 100 returned
+        var payloadItems = Enumerable.Range(0, 101)
+            .Select(i => (object)new { listened_at = 1740700000L + i, track_metadata = new { artist_name = "Clamp Max Pod", track_name = $"Ep {i}" } })
+            .ToArray();
+        await _client.PostAsJsonAsync("/1/submit-listens", new { listen_type = "import", payload = payloadItems });
+
+        var response = await _client.GetAsync("/1/user/default/listens?count=200");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var payload = content.GetProperty("payload");
+        Assert.Equal(100, payload.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public async Task GetListens_MaxTsFiltersResults()
+    {
+        // Submit two listens
+        var submitRequest1 = new
+        {
+            listen_type = "single",
+            payload = new[]
+            {
+                new
+                {
+                    listened_at = 1740400001L,
+                    track_metadata = new
+                    {
+                        artist_name = "MaxTs Test Pod",
+                        track_name = "Episode 1"
+                    }
+                }
+            }
+        };
+        await _client.PostAsJsonAsync("/1/submit-listens", submitRequest1);
+
+        var submitRequest2 = new
+        {
+            listen_type = "single",
+            payload = new[]
+            {
+                new
+                {
+                    listened_at = 1740400003L,
+                    track_metadata = new
+                    {
+                        artist_name = "MaxTs Test Pod",
+                        track_name = "Episode 2"
+                    }
+                }
+            }
+        };
+        await _client.PostAsJsonAsync("/1/submit-listens", submitRequest2);
+
+        // Query with max_ts=1740400002
+        var response = await _client.GetAsync("/1/user/default/listens?max_ts=1740400002");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var listens = content.GetProperty("payload").GetProperty("listens").EnumerateArray().ToList();
+
+        var listen1740400001 = listens.Any(l => l.GetProperty("listened_at").GetInt64() == 1740400001L);
+        var listen1740400003 = listens.Any(l => l.GetProperty("listened_at").GetInt64() == 1740400003L);
+
+        Assert.True(listen1740400001, "Listen at 1740400001 should appear");
+        Assert.False(listen1740400003, "Listen at 1740400003 should not appear (max_ts filters to <)");
+    }
+
+    [Fact]
+    public async Task GetListens_MinTsFiltersResults()
+    {
+        // Submit two listens
+        // Use timestamps well above all other tests' ranges to avoid pagination interference
+        var submitRequest1 = new
+        {
+            listen_type = "single",
+            payload = new[]
+            {
+                new
+                {
+                    listened_at = 1741100001L,
+                    track_metadata = new
+                    {
+                        artist_name = "MinTs Test Pod",
+                        track_name = "Episode 1"
+                    }
+                }
+            }
+        };
+        await _client.PostAsJsonAsync("/1/submit-listens", submitRequest1);
+
+        var submitRequest2 = new
+        {
+            listen_type = "single",
+            payload = new[]
+            {
+                new
+                {
+                    listened_at = 1741100003L,
+                    track_metadata = new
+                    {
+                        artist_name = "MinTs Test Pod",
+                        track_name = "Episode 2"
+                    }
+                }
+            }
+        };
+        await _client.PostAsJsonAsync("/1/submit-listens", submitRequest2);
+
+        // Query with min_ts=1741100002
+        var response = await _client.GetAsync("/1/user/default/listens?min_ts=1741100002");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var listens = content.GetProperty("payload").GetProperty("listens").EnumerateArray().ToList();
+
+        var listen1741100001 = listens.Any(l => l.GetProperty("listened_at").GetInt64() == 1741100001L);
+        var listen1741100003 = listens.Any(l => l.GetProperty("listened_at").GetInt64() == 1741100003L);
+
+        Assert.False(listen1741100001, "Listen at 1741100001 should not appear (min_ts filters to >)");
+        Assert.True(listen1741100003, "Listen at 1741100003 should appear");
+    }
 }

--- a/PodcastScrobbler.Tests/Endpoints/HealthEndpointTests.cs
+++ b/PodcastScrobbler.Tests/Endpoints/HealthEndpointTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace PodcastScrobbler.Tests.Endpoints;
+
+public class HealthEndpointTests : IClassFixture<ScrobblerWebApplicationFactory>
+{
+    private readonly ScrobblerWebApplicationFactory _factory;
+
+    public HealthEndpointTests(ScrobblerWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Health_Returns200WithHealthyStatus()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Token test-token");
+
+        var response = await client.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("healthy", body.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task Ready_Returns200WithReadyStatus()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Token test-token");
+
+        var response = await client.GetAsync("/ready");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("ready", body.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task Health_DoesNotRequireAuth()
+    {
+        var client = _factory.CreateClient();
+        // No Authorization header
+
+        var response = await client.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Ready_DoesNotRequireAuth()
+    {
+        var client = _factory.CreateClient();
+        // No Authorization header
+
+        var response = await client.GetAsync("/ready");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/PodcastScrobbler.Tests/Endpoints/StatsEndpointTests.cs
+++ b/PodcastScrobbler.Tests/Endpoints/StatsEndpointTests.cs
@@ -149,4 +149,61 @@ public class StatsEndpointTests : IClassFixture<ScrobblerWebApplicationFactory>
         Assert.False(first.TryGetProperty("ListenCount", out _), "Found PascalCase 'ListenCount'");
         Assert.False(first.TryGetProperty("TotalListenTimeMs", out _), "Found PascalCase 'TotalListenTimeMs'");
     }
+
+    [Fact]
+    public async Task RecentPodcasts_ReturnsDistinctPodcastNames()
+    {
+        await SubmitListen("Recent Pod A", "Ep 1", 1740250001L);
+        await SubmitListen("Recent Pod A", "Ep 2", 1740250002L);
+        await SubmitListen("Recent Pod B", "Ep 1", 1740250003L);
+
+        var response = await _client.GetAsync("/1/user/default/stats/recent-podcasts");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var payload = body.GetProperty("payload");
+        Assert.Equal(JsonValueKind.Array, payload.ValueKind);
+
+        var podcastNames = payload.EnumerateArray().Select(p => p.GetString()).ToList();
+        Assert.Contains("Recent Pod A", podcastNames);
+        Assert.Contains("Recent Pod B", podcastNames);
+        // Verify no duplicates — "Recent Pod A" was submitted twice but should appear only once
+        Assert.Equal(podcastNames.Distinct().Count(), podcastNames.Count);
+    }
+
+    [Fact]
+    public async Task Stats_UnknownUser_ReturnsEmptyOrZero()
+    {
+        var username = "unknown-user-xyz-never-exists";
+
+        // Test /stats/podcasts
+        var podcastsResponse = await _client.GetAsync($"/1/user/{username}/stats/podcasts");
+        Assert.Equal(HttpStatusCode.OK, podcastsResponse.StatusCode);
+        var podcastsBody = await podcastsResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var podcastsPayload = podcastsBody.GetProperty("payload");
+        Assert.Equal(0, podcastsPayload.GetArrayLength());
+
+        // Test /stats/weekly
+        var weeklyResponse = await _client.GetAsync($"/1/user/{username}/stats/weekly");
+        Assert.Equal(HttpStatusCode.OK, weeklyResponse.StatusCode);
+        var weeklyBody = await weeklyResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var weeklyPayload = weeklyBody.GetProperty("payload");
+        Assert.Equal(0, weeklyPayload.GetArrayLength());
+
+        // Test /stats/recent-podcasts
+        var recentResponse = await _client.GetAsync($"/1/user/{username}/stats/recent-podcasts");
+        Assert.Equal(HttpStatusCode.OK, recentResponse.StatusCode);
+        var recentBody = await recentResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var recentPayload = recentBody.GetProperty("payload");
+        Assert.Equal(0, recentPayload.GetArrayLength());
+
+        // Test /stats/summary
+        var summaryResponse = await _client.GetAsync($"/1/user/{username}/stats/summary");
+        Assert.Equal(HttpStatusCode.OK, summaryResponse.StatusCode);
+        var summaryBody = await summaryResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var summaryPayload = summaryBody.GetProperty("payload");
+        Assert.Equal(0, summaryPayload.GetProperty("total_listens").GetInt32());
+        Assert.Equal(0, summaryPayload.GetProperty("unique_podcasts").GetInt32());
+        Assert.Equal(0, summaryPayload.GetProperty("unique_episodes").GetInt32());
+    }
 }

--- a/PodcastScrobbler.Tests/Endpoints/SubmitListensTests.cs
+++ b/PodcastScrobbler.Tests/Endpoints/SubmitListensTests.cs
@@ -187,6 +187,53 @@ public class SubmitListensTests : IClassFixture<ScrobblerWebApplicationFactory>
         Assert.Equal("Internal server error", body.GetProperty("error").GetString());
     }
 
+    [Fact]
+    public async Task SubmitWithAdditionalInfo_RoundTrips()
+    {
+        var request = new
+        {
+            listen_type = "single",
+            payload = new[]
+            {
+                new
+                {
+                    listened_at = 1740300000L,
+                    track_metadata = new
+                    {
+                        artist_name = "AdditionalInfo Pod",
+                        track_name = "AdditionalInfo Episode",
+                        additional_info = new
+                        {
+                            podcast_feed_url = "https://example.com/feed.rss",
+                            episode_guid = "guid-abc-123",
+                            duration_ms = 3600000,
+                            position_ms = 1800000,
+                            percent_complete = 50.0
+                        }
+                    }
+                }
+            }
+        };
+
+        var submitResponse = await _client.PostAsJsonAsync("/1/submit-listens", request);
+        Assert.Equal(HttpStatusCode.OK, submitResponse.StatusCode);
+
+        var getResponse = await _client.GetAsync("/1/user/default/listens");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var body = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var listens = body.GetProperty("payload").GetProperty("listens").EnumerateArray();
+        var targetListen = listens.FirstOrDefault(l => l.GetProperty("listened_at").GetInt64() == 1740300000L);
+        Assert.False(targetListen.Equals(default(JsonElement)), "Could not find listen with timestamp 1740300000");
+
+        var additionalInfo = targetListen.GetProperty("track_metadata").GetProperty("additional_info");
+        Assert.Equal("https://example.com/feed.rss", additionalInfo.GetProperty("podcast_feed_url").GetString());
+        Assert.Equal("guid-abc-123", additionalInfo.GetProperty("episode_guid").GetString());
+        Assert.Equal(3600000, additionalInfo.GetProperty("duration_ms").GetInt32());
+        Assert.Equal(1800000, additionalInfo.GetProperty("position_ms").GetInt32());
+        Assert.Equal(50.0, additionalInfo.GetProperty("percent_complete").GetDouble());
+    }
+
     private sealed class ThrowingEndpointFilter : IStartupFilter
     {
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>

--- a/PodcastScrobbler.Tests/Middleware/OptionalTokenAuthTests.cs
+++ b/PodcastScrobbler.Tests/Middleware/OptionalTokenAuthTests.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using PodcastScrobbler.Config;
 
 namespace PodcastScrobbler.Tests.Middleware;
 
@@ -80,5 +83,29 @@ public class OptionalTokenAuthTests : IClassFixture<ScrobblerWebApplicationFacto
         var client = _factory.CreateClient();
         var response = await client.GetAsync("/1/validate-token?token=test-token");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_WithRequireAuthForReads_ReturnsUnauthorized()
+    {
+        await using var requireAuthFactory = new ScrobblerWebApplicationFactory()
+            .WithWebHostBuilder(b => b.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ScrobblerConfig));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(new ScrobblerConfig
+                {
+                    DatabasePath = ":memory:",
+                    ScrobblerToken = "test-token",
+                    RequireAuthForReads = true,
+                    Port = "5000"
+                });
+            }));
+
+        var client = requireAuthFactory.CreateClient();
+        // No Authorization header
+
+        var response = await client.GetAsync("/1/user/default/listens");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary

Adds integration test coverage for all previously untested endpoint groups and key edge cases.

## New tests (12 added, 47 total)

### `HealthEndpointTests.cs` (new file, 4 tests)
- `Health_Returns200WithHealthyStatus`
- `Ready_Returns200WithReadyStatus`
- `Health_DoesNotRequireAuth`
- `Ready_DoesNotRequireAuth`

### `StatsEndpointTests.cs` (2 new tests)
- `RecentPodcasts_ReturnsDistinctPodcastNames`
- `Stats_UnknownUser_ReturnsEmptyOrZero` — covers all 4 stats routes

### `SubmitListensTests.cs` (1 new test)
- `SubmitWithAdditionalInfo_RoundTrips` — full round-trip of all `additional_info` fields

### `GetListensTests.cs` (4 new tests)
- `GetListens_CountClampedToMinimum` — count=0 clamped to 1
- `GetListens_CountClampedToMaximum` — count=200 clamped to 100
- `GetListens_MaxTsFiltersResults` — `listened_at < max_ts`
- `GetListens_MinTsFiltersResults` — `listened_at > min_ts`

### `OptionalTokenAuthTests.cs` (1 new test)
- `ReadEndpoint_WithRequireAuthForReads_ReturnsUnauthorized`

Closes #6